### PR TITLE
Update Feature Centered 2x2 grid

### DIFF
--- a/pages/preview/features/c2g/index.js
+++ b/pages/preview/features/c2g/index.js
@@ -116,7 +116,7 @@ export default function C2g() {
 
               <Feature
                 title=" No hidden fees"
-                description={
+                icon={
                   <path
                     strokeLinecap="round"
                     strokeLinejoin="round"
@@ -148,7 +148,7 @@ export default function C2g() {
 
               <Feature
                 title="Mobile notifications"
-                description={
+                icon={
                   <path
                     strokeLinecap="round"
                     strokeLinejoin="round"


### PR DESCRIPTION
The icons shown in front of each feature item was not showing up. It was caused by the typo (instead of "icon", value of "description" was being set for two items).

I have fixed the typo and it is working as expected now. https://choc-ui-git-fork-sufianbabri-patch-1-anubra266.vercel.app/preview/features/c2g

By the way, thank you for these excellent components. They are really neat and look awesome!