### PR TITLE
Fixed the issue where 'With Angled Image' Hero section has a slight line to the image's top

### DIFF
--- a/pages/preview/heros/twai/index.js
+++ b/pages/preview/heros/twai/index.js
@@ -128,6 +128,7 @@ const KuttyHero = () => {
         bottom={{ lg: 0 }}
         right={{ lg: 0 }}
         w={{ lg: "50%" }}
+        border='solid 1px transparent'
       >
         <Image
           h={[56, 72, 96, "full"]}


### PR DESCRIPTION
There was a slight line (of height 1px) on the image visible behind the polygon which gave the image a slanting-cut effect. It was more easily visible in dark mode.

Adding a transparent border to the Box, containing the image, fixes it.

For reference, I've marked the problematic area with a red rectangle:

![Screenshot from 2021-07-22 01-05-50](https://user-images.githubusercontent.com/9989266/126553321-b2569882-945a-437c-9948-75a04a7f624a.png)

