### PR TITLE
fix: show ctrl key on windows/linux and command key on mac in the search box

### DIFF
--- a/components/doc-search/index.tsx
+++ b/components/doc-search/index.tsx
@@ -20,13 +20,13 @@ export default function SearchBar(props) {
   const [actionKey, setActionKey] = React.useState(ACTION_KEY_APPLE);
   React.useEffect(() => {
     if (typeof navigator === "undefined") return;
-    const isMac = /(Mac|iPhone|iPod|iPad)/i.test(navigator.platform);
+    const isMac = /(Mac|iPhone|iPod|iPad)/i.test(navigator.userAgent);
     if (!isMac) {
       setActionKey(ACTION_KEY_DEFAULT);
     }
   }, []);
-  useEventListener("keydown", (event) => {
-    const isMac = /(Mac|iPhone|iPod|iPad)/i.test(navigator?.platform);
+  useEventListener("keydown", event => {
+    const isMac = /(Mac|iPhone|iPod|iPad)/i.test(navigator?.userAgent);
     const hotkey = isMac ? "metaKey" : "ctrlKey";
     if (event.key.toLowerCase() === "k" && event[hotkey]) {
       event.preventDefault();
@@ -72,7 +72,7 @@ export default function SearchBar(props) {
                 title={actionKey[1]}
                 textDecoration="none !important"
               >
-                {ACTION_KEY_APPLE[0]}
+                {actionKey[0]}
               </chakra.div>
             </Kbd>
             <VisuallyHidden> and </VisuallyHidden>


### PR DESCRIPTION
closes #63 

I have also switched to `navigator.userAgent` from `navigator.platform` (for determining platform) as the latter has been deprecated (reference: https://developer.mozilla.org/en-US/docs/Web/API/Navigator/platform).

With a Windows user-agent:
![image](https://user-images.githubusercontent.com/63192115/145223846-83da3b3f-8b3b-4e35-a723-1cdf7cd7ba8f.png)

With a macOS user-agent:
![image](https://user-images.githubusercontent.com/63192115/145223959-605b97d2-a54d-4874-bd99-d0cd3a585d1e.png)
