### PR TITLE
Fixed dark mode design of the CPWE card (dark text to white text)

### DIFF
--- a/pages/preview/cards/cpwe/index.tsx
+++ b/pages/preview/cards/cpwe/index.tsx
@@ -60,11 +60,12 @@ const Choc = () => {
             as="h4"
             lineHeight="tight"
             noOfLines={1}
+            _dark={{ color: "white" }}
           >
             {property.title}
           </Text>
 
-          <Box>
+          <Box _dark={{ color: "white" }}>
             {property.formattedPrice}
             <Box as="span" color="gray.600" fontSize="sm">
               / wk


### PR DESCRIPTION
The text of the [Product With Evaluation 2](https://choc-ui.com/docs/elements/cards#cards/cpwe) card in dark mode was left black, which negatively impacted the UX (making it difficult to read).
Added `_dark` props to the elements affected.

Before:
<img width="390" alt="Screenshot 2024-06-27 at 11 15 56" src="https://github.com/anubra266/choc-ui/assets/19559116/b7f4f3f0-c57c-4f16-a685-205e232c4b4e">

After:
<img width="392" alt="Screenshot 2024-06-27 at 11 15 42" src="https://github.com/anubra266/choc-ui/assets/19559116/289640b8-99ac-48b6-9903-14dae07b7519">
